### PR TITLE
chore: harmonize with caian-org baseline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+end_of_line              = lf
+insert_final_newline     = true
+charset                  = utf-8
+trim_trailing_whitespace = true
+indent_style             = space
+
+[*.go]
+indent_style = tab
+
+[*.{yml,yaml,json,html,css,js}]
+indent_size = 2
+
+[*.sh]
+indent_size = 4
+
+[.justfile]
+indent_size = 2

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+dotenv_if_exists .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
-          args: --timeout=5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,30 @@
+run:
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+    - revive
+    - gofmt
+    - goimports
+
+linters-settings:
+  revive:
+    rules:
+      - name: unused-parameter
+        disabled: true
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+        - revive
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,30 +1,45 @@
-run:
-  timeout: 5m
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - govet
     - ineffassign
-    - staticcheck
-    - unused
     - misspell
     - revive
-    - gofmt
-    - goimports
-
-linters-settings:
-  revive:
+    - staticcheck
+    - unused
+  settings:
+    revive:
+      rules:
+        - name: unused-parameter
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      - name: unused-parameter
-        disabled: true
-
+      - linters:
+          - errcheck
+          - revive
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck
-        - revive
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,12 @@
 version: 2
 
+before:
+  hooks:
+    - go mod tidy
+
 builds:
-  - main: ./cmd/tpsp
+  - id: tpsp
+    main: ./cmd/tpsp
     binary: tpsp
     env:
       - CGO_ENABLED=0
@@ -12,19 +17,52 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w
+      - -X main.Version={{ .Version }}
+      - -X main.Commit={{ .ShortCommit }}
+      - -X main.BuildDate={{ .Date }}
 
 archives:
-  - formats:
+  - ids:
+      - tpsp
+    formats:
       - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
         formats:
           - zip
+    files:
+      - README.md
+      - LICENSE*
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
 
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
       - "^docs:"
       - "^test:"
+      - "^chore:"
+      - "^ci:"
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+
+release:
+  draft: false
+  prerelease: auto
+  name_template: '{{ .ProjectName }} {{ .Version }}'

--- a/.justfile
+++ b/.justfile
@@ -1,5 +1,7 @@
 set shell := ["/bin/bash", "-c"]
 
+BIN := "bin/tpsp"
+
 # --------------------------------------------------------------------------------------------------
 
 _help:
@@ -10,9 +12,35 @@ _help:
 # build tpsp into bin/tpsp
 build:
     @mkdir -p bin
-    @go build -o bin/tpsp ./cmd/tpsp
+    @go build -o {{ BIN }} ./cmd/tpsp
     @echo "built tpsp"
 
-# remove generated binary
+# run go test ./...
+test:
+    go test ./...
+
+# run the test suite with the race detector
+test-race:
+    go test -race ./...
+
+# coverage profile + per-function totals
+cover:
+    go test -coverprofile=coverage.out ./...
+    go tool cover -func=coverage.out | tail -20
+
+# go vet (CI also runs golangci-lint)
+lint:
+    go vet ./...
+
+# go mod tidy
+tidy:
+    go mod tidy
+
+# remove build outputs
 clean:
-    @rm -f bin/tpsp
+    rm -rf bin coverage.out
+
+# build then run bin/tpsp with the given args
+run *ARGS:
+    @just build
+    @{{ BIN }} {{ ARGS }}

--- a/cmd/tpsp/main.go
+++ b/cmd/tpsp/main.go
@@ -11,10 +11,16 @@ import (
 
 const (
 	programName        = "tpsp"
-	programVersion     = "2.0.4"
 	programDescription = "CLI for Sao Paulo public transportation line status"
 	programURL         = "https://github.com/caian-org/tpsp"
 	apiURL             = "https://www.tictrens.com.br/helper/line-statuses"
+)
+
+// Injected at release time via -ldflags by goreleaser.
+var (
+	Version   = "0.0.0-dev"
+	Commit    = "none"
+	BuildDate = "unknown"
 )
 
 const copyrightInfo = `
@@ -291,7 +297,11 @@ func main() {
 
 	// Handle --version
 	if showVersion {
-		fmt.Printf("%s (%s)\n", programName, programVersion)
+		if Commit != "none" {
+			fmt.Printf("%s %s (%s, %s)\n", programName, Version, Commit, BuildDate)
+		} else {
+			fmt.Printf("%s (%s)\n", programName, Version)
+		}
 		os.Exit(0)
 	}
 

--- a/cmd/tpsp/main_test.go
+++ b/cmd/tpsp/main_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetColorForStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusColor string
+		want        string
+	}{
+		{"verde lowercase", "verde", colorGreen},
+		{"verde uppercase", "VERDE", colorGreen},
+		{"verde mixed case", "Verde", colorGreen},
+		{"amarelo lowercase", "amarelo", colorYellow},
+		{"amarelo uppercase", "AMARELO", colorYellow},
+		{"vermelho lowercase", "vermelho", colorRed},
+		{"vermelho uppercase", "VERMELHO", colorRed},
+		{"cinza lowercase", "cinza", colorDim},
+		{"cinza mixed case", "Cinza", colorDim},
+		{"unknown color falls back to reset", "azul", colorReset},
+		{"empty string falls back to reset", "", colorReset},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, getColorForStatus(tc.statusColor))
+		})
+	}
+}
+
+func TestFormatLineName(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"Linha-Verde becomes Verde", "Linha-Verde", "Verde"},
+		{"Linha-AZUL becomes Azul", "Linha-AZUL", "Azul"},
+		{"Linha-amarela becomes Amarela", "Linha-amarela", "Amarela"},
+		{"single segment lowercase", "vermelha", "Vermelha"},
+		{"single segment uppercase", "PRATA", "Prata"},
+		{"empty string returns empty", "", ""},
+		{"multiple dashes uses last", "Linha-Expresso-Turquesa", "Turquesa"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, formatLineName(tc.line))
+		})
+	}
+}
+
+func TestNormalizeStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{"operações normais lowercase", "operações normais", "Operação Normal"},
+		{"operações normais mixed case", "Operações Normais", "Operação Normal"},
+		{"operações encerradas lowercase", "operações encerradas", "Operação Encerrada"},
+		{"operações encerradas uppercase", "OPERAÇÕES ENCERRADAS", "Operação Encerrada"},
+		{"unknown status passes through", "Velocidade Reduzida", "Velocidade Reduzida"},
+		{"trims leading and trailing spaces", "   operações normais   ", "Operação Normal"},
+		{"passthrough with trim", "  Paralisada  ", "Paralisada"},
+		{"empty string remains empty", "", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeStatus(tc.status))
+		})
+	}
+}
+
+func TestIsValidService(t *testing.T) {
+	tests := []struct {
+		name    string
+		service string
+		want    bool
+	}{
+		{"metro lowercase", "metro", true},
+		{"Metro title case", "Metro", true},
+		{"METRO uppercase", "METRO", true},
+		{"cptm lowercase", "cptm", true},
+		{"viamobilidade", "viamobilidade", true},
+		{"viaquatro", "viaquatro", true},
+		{"ônibus is invalid", "ônibus", false},
+		{"empty string is invalid", "", false},
+		{"random word is invalid", "trem", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isValidService(tc.service))
+		})
+	}
+}
+
+func TestFilterByService(t *testing.T) {
+	data := []ServiceData{
+		{
+			Type: "metro",
+			ListItem: []LineItem{
+				{Line: "Linha-Azul", Status: "Operação Normal"},
+				{Line: "Linha-Verde", Status: "Operação Normal"},
+			},
+		},
+		{
+			Type: "cptm",
+			ListItem: []LineItem{
+				{Line: "Linha-Rubi", Status: "Operação Normal"},
+			},
+		},
+	}
+
+	t.Run("empty filter returns all lines", func(t *testing.T) {
+		got := filterByService(data, "")
+		assert.Len(t, got, 3)
+	})
+
+	t.Run("metro filter returns only metro lines", func(t *testing.T) {
+		got := filterByService(data, "metro")
+		assert.Len(t, got, 2)
+		assert.Equal(t, "Linha-Azul", got[0].Line)
+		assert.Equal(t, "Linha-Verde", got[1].Line)
+	})
+
+	t.Run("cptm filter returns only cptm lines", func(t *testing.T) {
+		got := filterByService(data, "cptm")
+		assert.Len(t, got, 1)
+		assert.Equal(t, "Linha-Rubi", got[0].Line)
+	})
+
+	t.Run("filter is case-insensitive", func(t *testing.T) {
+		got := filterByService(data, "METRO")
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("unknown service returns no lines", func(t *testing.T) {
+		got := filterByService(data, "unknown")
+		assert.Empty(t, got)
+	})
+}

--- a/devbox.json
+++ b/devbox.json
@@ -10,9 +10,9 @@
       "echo 'Welcome to devbox!' > /dev/null"
     ],
     "scripts": {
-      "test": [
-        "echo \"Error: no test specified\" && exit 1"
-      ]
+      "test": ["just test"],
+      "release-check": ["goreleaser check"],
+      "release-snapshot": ["goreleaser release --snapshot --clean"]
     }
   }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,37 @@
-# TPSP: Transporte Público de São Paulo
+[![CI][ci-shield]][ci-url]
+[![Release][rel-shield]][rel-url]
+[![GitHub tag][tag-shield]][tag-url]
 
-`tpsp` (acrônimo para "Transporte Público de São Paulo") é uma pequena aplicação
-de linha de comando que exibe o estado atual das linhas do [Metro], [CPTM],
-[ViaMobilidade] e [ViaQuatro].
+# `tpsp`
 
-**AVISO: Este projeto não possui relações com o Estado de São Paulo, a CPTM, o
-Metro ou qualquer outro órgão governamental.**
+`tpsp` (acrônimo para "Transporte Público de São Paulo") é uma pequena
+aplicação de linha de comando que exibe o estado atual das linhas do
+[Metro][metro], [CPTM][cptm], [ViaMobilidade][viamobilidade] e
+[ViaQuatro][viaquatro].
 
-[Metro]: http://www.metro.sp.gov.br
-[CPTM]: https://www.cptm.sp.gov.br
-[ViaMobilidade]: https://www.viamobilidade.com.br
-[ViaQuatro]: https://www.viaquatro.com.br
+> **AVISO**: Este projeto não possui relações com o Estado de São Paulo,
+> a CPTM, o Metro ou qualquer outro órgão governamental.
+
+[ci-shield]: https://img.shields.io/github/actions/workflow/status/caian-org/tpsp/ci.yml?label=ci&logo=github&style=flat-square
+[ci-url]: https://github.com/caian-org/tpsp/actions/workflows/ci.yml
+[rel-shield]: https://img.shields.io/github/actions/workflow/status/caian-org/tpsp/release.yml?label=release&logo=github&style=flat-square
+[rel-url]: https://github.com/caian-org/tpsp/actions/workflows/release.yml
+[tag-shield]: https://img.shields.io/github/tag/caian-org/tpsp.svg?logo=git&logoColor=FFF&style=flat-square
+[tag-url]: https://github.com/caian-org/tpsp/releases
+
+[metro]: http://www.metro.sp.gov.br
+[cptm]: https://www.cptm.sp.gov.br
+[viamobilidade]: https://www.viamobilidade.com.br
+[viaquatro]: https://www.viaquatro.com.br
 
 
 ## Requerimentos
 
 - Go 1.26 ou superior (apenas para compilação)
-- just (apenas para compilação)
+- [just][just] (apenas para compilação)
 - Docker (opcional, para uso via imagem de container)
+
+[just]: https://github.com/casey/just
 
 
 ## Compilação
@@ -27,34 +41,6 @@ just build
 ```
 
 O binário será gerado em `bin/tpsp`.
-
-
-## Docker
-
-A imagem oficial do projeto é publicada no GitHub Container Registry:
-
-```sh
-docker pull ghcr.io/caian-org/tpsp:latest
-```
-
-Também é possível usar uma versão específica:
-
-```sh
-docker pull ghcr.io/caian-org/tpsp:v2.0.4
-```
-
-Exemplos:
-
-```sh
-# Exibe o estado de todas as linhas
-docker run --rm ghcr.io/caian-org/tpsp:latest
-
-# Exibe apenas as linhas do Metro
-docker run --rm ghcr.io/caian-org/tpsp:latest metro
-
-# Exibe as linhas da CPTM em formato JSON
-docker run --rm ghcr.io/caian-org/tpsp:latest cptm --json
-```
 
 
 ## Uso
@@ -90,13 +76,78 @@ tpsp metro
 tpsp cptm --json
 ```
 
+Saída de exemplo:
+
+```
+Linha              Status
+---------------------------------
+Azul               Operação Normal
+Verde              Operação Normal
+Vermelha           Operação Normal
+Amarela            Operação Normal
+Lilás              Operação Normal
+Prata              Operação Normal
+```
+
+
+### Saída em JSON
+
+```json
+{
+    "code": 200,
+    "data": [
+        {
+            "line": "Azul",
+            "status": "Operação Normal"
+        },
+        {
+            "line": "Verde",
+            "status": "Operação Normal"
+        }
+    ],
+    "message": "success"
+}
+```
+
+
+## Docker
+
+A imagem oficial do projeto é publicada no GitHub Container Registry:
+
+```sh
+docker pull ghcr.io/caian-org/tpsp:latest
+```
+
+Também é possível usar uma versão específica:
+
+```sh
+docker pull ghcr.io/caian-org/tpsp:v2.0.4
+```
+
+Exemplos:
+
+```sh
+# Exibe o estado de todas as linhas
+docker run --rm ghcr.io/caian-org/tpsp:latest
+
+# Exibe apenas as linhas do Metro
+docker run --rm ghcr.io/caian-org/tpsp:latest metro
+
+# Exibe as linhas da CPTM em formato JSON
+docker run --rm ghcr.io/caian-org/tpsp:latest cptm --json
+```
+
 
 ## Licença
 
-Na medida do possível sob a lei, [Caian Ertl][me] renunciou a __todos os
-direitos autorais e direitos relacionados ou adjacentes a este trabalho__. No
-espírito da _liberdade de informação_, encorajo você a forkar, modificar,
-alterar, compartilhar ou fazer o que quiser com este projeto! [`^ C ^ V`][kopimi]
+Na medida do permitido por lei, [Caian Ertl][me] renunciou a __todos os
+direitos autorais e direitos conexos a este trabalho__. No espírito de
+_liberdade de informação_, você é encorajado a clonar, modificar, distribuir,
+compartilhar ou fazer o que quiser com este projeto! [`^C ^V`][kopimi]
 
-[me]: https://github.com/caian-org
+[![Licença][cc-shield]][cc-url]
+
+[me]: https://github.com/upsetbit
+[cc-shield]: https://forthebadge.com/images/badges/cc-0.svg
+[cc-url]: http://creativecommons.org/publicdomain/zero/1.0
 [kopimi]: https://kopimi.com

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/caian-org/tpsp
 
 go 1.26
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary

Aligns `tpsp` with the caian-org repo baseline: shared dotfiles, expanded justfile, golangci config, enriched goreleaser (ldflags + checksum sha256 + grouped changelog), version metadata injection, unit tests, README refresh with shields.

## Changes

- Add `.editorconfig`, `.envrc`, `.golangci.yml`
- Expand devbox scripts and `.justfile` targets (`test`, `test-race`, `cover`, `lint`, `tidy`, `clean`, `run`)
- Inject `Version`/`Commit`/`BuildDate` via goreleaser ldflags; expose via `--version`
- Enrich `.goreleaser.yaml`: `before` hooks, sha256 checksum, grouped changelog, archive README/LICENSE
- Add unit tests with testify for color/format/filter/validation helpers
- Refresh README with shields.io badges (CI / release / tag) and license block

## Test plan

- [x] `just build`
- [x] `just test`
- [x] `just lint`
- [x] `goreleaser check`
- [ ] CI green on PR